### PR TITLE
Change memory resource key in SLURM config

### DIFF
--- a/src/profiles/slurm/config.yaml
+++ b/src/profiles/slurm/config.yaml
@@ -2,7 +2,7 @@
 # Usage: snakemake --profile src/profiles/slurm
 
 # Slurm cluster configuration
-cluster: "sbatch --account={cluster.account} --partition={cluster.partition} --qos={cluster.qos} --cpus-per-task={threads} --mem={resources.memory}G --time={cluster.time} --job-name={params.job_name} --output=rule_logs/%x.out --error=rule_logs/%x.err"
+cluster: "sbatch --account={cluster.account} --partition={cluster.partition} --qos={cluster.qos} --cpus-per-task={threads} --mem={resources.mem_gb}G --time={cluster.time} --job-name={params.job_name} --output=rule_logs/%x.out --error=rule_logs/%x.err"
 cluster-config: "src/profiles/slurm/cluster.yaml"
 
 # Job submission settings


### PR DESCRIPTION
Updated memory resource key from 'memory' to 'mem_gb' in SLURM cluster configuration.