### PR TITLE
Fix Spearman correlation bug and unify BH multiple-testing correction

### DIFF
--- a/src/Rmds/pause-quant-template.Rmd
+++ b/src/Rmds/pause-quant-template.Rmd
@@ -364,7 +364,7 @@ create_stat_corr <- function(df_in, x, y, ttl = NULL,
     mutate(
       n     = n_distinct(name),
       n     = str_c("n = ", comma(n)),
-      corr  = list(broom::tidy(cor.test(log10(!!sym(x)), !!sym(y), method = "spearman"))),
+      corr  = list(broom::tidy(cor.test(!!sym(x), !!sym(y), method = "spearman"))),
       r     = map_dbl(corr, ~ .x$estimate),
       r     = round(r, 2),
       r     = str_c("r = ", r),
@@ -514,8 +514,7 @@ plot_ex_int_pauses <- function(df_in, y = "p-reads_NET", y_ttl = "fraction pause
       mutate(
         p = ifelse(p == 0, "0", scientific(p, 2)),
         p = str_c(n, "\np = ", p)
-      ) %>%
-      distinct()
+      )
 
     dat <- dat %>%
       left_join(lab_dat, by = c(p_grps, "n")) %>%

--- a/src/Rmds/pause-quant-template.Rmd
+++ b/src/Rmds/pause-quant-template.Rmd
@@ -505,8 +505,13 @@ plot_ex_int_pauses <- function(df_in, y = "p-reads_NET", y_ttl = "fraction pause
         p = (wilcox.test(exons, introns))$p.value,
         .groups = "drop"
       ) %>%
+      # Stratify BH by the non-sample components of p_grps so distinct
+      # biological comparisons (e.g. first vs body exon class) are
+      # corrected as separate families rather than pooled.
+      group_by(!!!syms(setdiff(p_grps, "sample"))) %>%
+      mutate(p = p.adjust(p, method = "BH")) %>%
+      ungroup() %>%
       mutate(
-        p = p.adjust(p, method = "BH"),
         p = ifelse(p == 0, "0", scientific(p, 2)),
         p = str_c(n, "\np = ", p)
       ) %>%

--- a/src/Rmds/pause-quant-template.Rmd
+++ b/src/Rmds/pause-quant-template.Rmd
@@ -113,8 +113,6 @@ create_stat_boxes <- function(df_in, metric, by = c("rep", "type", "region"),
   
   # Calculate p-value for treats
   if (n_trts > 1) {
-    n_tests <- n_groups(dat)
-    
     dat <- dat %>%
       mutate(
         p = list(broom::tidy(
@@ -122,17 +120,23 @@ create_stat_boxes <- function(df_in, metric, by = c("rep", "type", "region"),
         )),
         p = map_dbl(p, ~ .x$p.value)
       )
-    
+
     # Correct for multiple testing
+    # BH must operate on the full vector of distinct per-panel p-values;
+    # adjusting rowwise would degenerate to Bonferroni.
+    adj_dat <- dat %>%
+      distinct(!!!syms(by), p) %>%
+      ungroup() %>%
+      mutate(p = p.adjust(p, method = "BH"))
+
     dat <- dat %>%
-      rowwise() %>%
+      dplyr::select(-p) %>%
+      left_join(adj_dat, by = by) %>%
       mutate(
-        p = p.adjust(p, method = "bonferroni", n = n_tests),
         p = scientific(p, digits = 2),
         bx_lab = p
-      ) %>%
-      ungroup()
-    
+      )
+
     if (n_n > 1) {
       dat <- dat %>%
         mutate(bx_lab = str_c(n, "\n", p))
@@ -360,7 +364,7 @@ create_stat_corr <- function(df_in, x, y, ttl = NULL,
     mutate(
       n     = n_distinct(name),
       n     = str_c("n = ", comma(n)),
-      corr  = list(broom::tidy(cor.test(log10(!!sym(x)), !!sym(y)), method = "spearman")),
+      corr  = list(broom::tidy(cor.test(log10(!!sym(x)), !!sym(y), method = "spearman"))),
       r     = map_dbl(corr, ~ .x$estimate),
       r     = round(r, 2),
       r     = str_c("r = ", r),
@@ -499,12 +503,15 @@ plot_ex_int_pauses <- function(df_in, y = "p-reads_NET", y_ttl = "fraction pause
       group_by(!!!syms(c(p_grps, "n"))) %>%
       summarize(
         p = (wilcox.test(exons, introns))$p.value,
-        p = ifelse(p == 0, "0", scientific(p, 2)),
-        p = str_c(n, "\np = ", p),
         .groups = "drop"
       ) %>%
+      mutate(
+        p = p.adjust(p, method = "BH"),
+        p = ifelse(p == 0, "0", scientific(p, 2)),
+        p = str_c(n, "\np = ", p)
+      ) %>%
       distinct()
-    
+
     dat <- dat %>%
       left_join(lab_dat, by = c(p_grps, "n")) %>%
       mutate(n = p)
@@ -1018,164 +1025,6 @@ first_bxs
 
 ```
 
-```{r "{{grp}} EXON INTRON TEST PLOTS", eval = FALSE}
-
-# Calculate stats
-NET_kb_min <- 25
-
-create_ex_int_plots <- function(NET_kb_min = 0) {
-  
-  plt_dat <- res %>%
-    pivot_wider(names_from = type, values_from = counts) %>%
-    dplyr::filter(
-      gene_name %in% pause_ex_int_genes,
-      NET / (len / 1000) > NET_kb_min
-    ) %>%
-    
-    # group_by(sample, gene_name) %>%
-    # dplyr::filter(all(names(regs) %in% region)) %>%
-    # ungroup() %>%
-    
-    calc_pause_stats() %>%
-    
-    group_by(sample, region) %>%
-    mutate(
-      n = n_distinct(gene_name),
-      n = str_c("n = ", comma(n))
-    ) %>%
-    ungroup()
-  
-  # Create violin plots
-  vlns <- plt_dat %>%
-    dplyr::filter(type == "p-reads_NET") %>%
-    ggplot(aes(region, counts, alpha = region, fill = treat)) +
-    
-    # geom_boxplot(fill = clrs, outlier.size = 0.5, outlier.alpha = 1) +
-    
-    geom_violin(draw_quantiles = c(0.25, 0.75)) +
-    stat_summary(geom = "point", fun = median, alpha = 1) +
-    
-    geom_text(
-      aes(region, Inf, label = n),
-      # hjust = 1.1,
-      vjust = 1.1,
-      check_overlap = TRUE,
-      color = "black",
-      alpha = 1
-    ) +
-    
-    scale_alpha_manual(values = c(0.3, 0.6)) +
-    scale_fill_manual(values = clrs) +
-    facet_wrap(~ sample, scales = "free") +
-    labs(y = "fraction pause reads") +
-    theme_info +
-    theme(
-      legend.position = "none",
-      axis.title.x    = element_blank()
-    )
-  
-  # Scatter plots
-  s_dat <- plt_dat %>%
-    pivot_wider(names_from = type, values_from = counts)
-  
-  s_dat <- s_dat %>%
-    group_by(rep, region) %>%
-    mutate(
-      r = cor(`p-reads_NET`, log10(NET_kb)),
-      r = round(r, 2),
-      n = str_c(n, "\nr = ", r)
-    )
-  
-  sctrs <- s_dat %>%
-    ggplot(aes(NET_kb, `p-reads_NET`)) +
-    geom_pointdensity() +
-    
-    geom_smooth(method = "lm", linetype = 2, size = 1, color = "black") +
-    
-    geom_text(
-      aes(Inf, Inf, label = n),
-      hjust = 1.1,
-      vjust = 1.1,
-      check_overlap = TRUE
-    ) +
-    
-    scale_color_gradientn(colours = c("black", "red")) +
-    facet_grid(rep ~ region) +
-    scale_x_log10() +
-    theme_info
-  
-  # Create final figure
-  plot_grid(
-    vlns, sctrs,
-    nrow = 1,
-    rel_widths = c(0.5, 1)
-  )
-}
-
-calc_ex_int_p <- function(NET_kb_min) {
-  plt_dat <- res %>%
-    pivot_wider(names_from = type, values_from = counts) %>%
-    dplyr::filter(
-      gene_name %in% pause_ex_int_genes,
-      NET / (len / 1000) > NET_kb_min
-    ) %>%
-    
-    # group_by(sample, gene_name) %>%
-    # dplyr::filter(all(names(regs) %in% region)) %>%
-    # ungroup() %>%
-    
-    calc_pause_stats() %>%
-    
-    group_by(sample, region) %>%
-    mutate(
-      n = n_distinct(gene_name),
-      n = str_c("n = ", comma(n))
-    ) %>%
-    ungroup()
-  
-  plt_dat %>% 
-    dplyr::select(-n, -len) %>%
-    dplyr::filter(type %in% c("p-reads_NET")) %>%
-    pivot_wider(names_from = region, values_from = counts) %>%
-    group_by(sample) %>%
-    summarize(p = broom::tidy(wilcox.test(exons, introns))$p.value) %>%
-    mutate(cutoff = NET_kb_min)
-}
-
-plts <- seq(0, 100, 20) %>%
-  map(create_ex_int_plots)
-
-plot_grid(plotlist = plts, align = "vh", axis = "trbl")
-
-# p-values
-df <- c(0, 10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 550, 1000) %>%
-  map_dfr(calc_ex_int_p)
-
-# # Exon/intron scatter plots
-# plt_dat <- ex_int_beds %>%
-#   mutate(len = end - start) %>%
-#   pivot_wider(names_from = type, values_from = counts) %>%
-#   calc_pause_stats()
-# 
-# plt_dat %>%
-#   pivot_wider(names_from = type, values_from = counts) %>%
-#   dplyr::filter(pauses > 0) %>%
-#   ggplot(aes(NET_kb, `p-reads_NET`)) +
-#   geom_pointdensity() +
-#   scale_x_log10() +
-#   facet_grid(sample ~ region) +
-#   geom_smooth(method = "lm", linetype = 2, size = 1) +
-#   theme_info
-
-# # Plot other stats
-# plt_dat %>%
-#   dplyr::filter(type %in% stats) %>%
-#   ggplot(aes(region, counts / (len / 1000), alpha = region, fill = type)) +
-#   geom_boxplot() +
-#   facet_wrap(sample ~ type, scales = "free") +
-#   scale_y_log10()
-
-```
 
 <br>
 

--- a/src/Rmds/pause-zone-template.Rmd
+++ b/src/Rmds/pause-zone-template.Rmd
@@ -701,15 +701,23 @@ h_dat <- zones %>%
   pivot_wider(names_from = "treat", values_from = "zone")
 
 # Calculate p-values
+# Compute one p-value per (group, rep) and BH-adjust across that family;
+# joining back broadcasts the adjusted p-value to every gene-level row.
 if (n_treats > 1 && n_reps == n_common_reps) {
-  h_dat <- h_dat %>%
+  p_dat <- h_dat %>%
     group_by(group, rep) %>%
+    summarize(
+      p = wilcox.test(!!!syms(fc_treats))$p.value,
+      .groups = "drop"
+    ) %>%
+    mutate(p = p.adjust(p, method = "BH"))
+
+  h_dat <- h_dat %>%
+    left_join(p_dat, by = c("group", "rep")) %>%
     mutate(
-      p     = wilcox.test(!!!syms(fc_treats))$p.value,
       p     = scientific(p, digits = 2),
       n_lab = str_c(n, "\n", p)
-    ) %>%
-    ungroup()
+    )
 }
   
 # Check for NAs


### PR DESCRIPTION
## Summary

- **Fix silently-Pearson `cor.test`** in `pause-quant-template.Rmd:367`. The `method = "spearman"` argument was outside `cor.test()` and being absorbed by `broom::tidy()`'s `...`, so the actual computation was Pearson on `log10(x)` vs raw `y` while the displayed `r` label and surrounding prose claimed Spearman. Argument moved inside `cor.test()`; redundant `log10()` wrapper removed (Spearman is rank-invariant under monotonic transforms).
- **Unify multiple-testing correction across Wilcoxon families.** Previously one site applied Bonferroni inside `rowwise()` (which would degenerate to Bonferroni-equivalent if naively swapped to BH, since rank-based BH needs the full p-value vector), and two other sites had no correction at all. All three now use a `summarize → mutate(p.adjust(method = "BH")) → join/format` pattern, with the BH family scoped to the panels visible in each figure.
- **Stratify BH by `region_class`** at the second exons-vs-introns call site (`pause-quant-template.Rmd:498-518`). Previously, `p_grps = c("region_class", "sample")` pooled biologically distinct comparisons (first exon/intron vs body exon/intron) into one BH vector. Now wrapped in `group_by(setdiff(p_grps, "sample"))` so each region class gets its own correction. The default `p_grps = "sample"` continues to behave identically (the `setdiff` returns empty and `group_by()` is a no-op).
- **Delete `EXON INTRON TEST PLOTS` dead chunk** (`eval = FALSE`, never rendered). Contained a default-Pearson `cor()`, a 15-cutoff uncorrected Wilcoxon scan, and other unrelated stats issues. Removed to prevent accidental re-enable. The underlying sensitivity-scan idea is captured in the follow-up issue noted below.
- **Polish:** drop redundant `log10()` inside Spearman cor.test (rank-invariant) and a trailing no-op `distinct()` after `summarize(.groups = "drop")`.

## Deferred to follow-up

Two related methods WARNINGs surfaced by the audit but not addressed here (they share a structural fix that doesn't belong in this commit):

- **M-W1** — The TSS-vs-body Wilcoxon runs per-replicate inside `common_reps %>% map(...)`, with the BH family reducing to 2 p-values per panel. Cross-replicate multiplicity unaccounted.
- **M-W3** — The exons-vs-introns Wilcoxon is computed per `sample` (treat × rep), treating biological replicates as independent tests rather than aggregating to per-replicate.

Both require moving the unit of inference from "per-replicate gene-axis test" to "cross-replicate aggregated test" (or a mixed-effects model). To be filed as a single follow-up issue and addressed in its own PR.

## Test plan

- [ ] Re-render `results/{PROJ}_analysis.html` on a representative dataset (cached objects under `objects/` auto-regenerate because `plot_params\$overwrite` defaults to `true`).
- [ ] Spot-check the pause-quant scatter plots: the displayed `r =` value should now reflect Spearman rank correlation. Previous Pearson-on-log10 values will differ.
- [ ] Spot-check the TSS/body and exons-vs-introns boxplot panels: p-value labels should still render in scientific notation; the BH adjustment runs on the per-panel / per-figure family.
- [ ] Confirm no rendering errors after the `EXON INTRON TEST PLOTS` chunk deletion (the section between `EXON INTRON PLOTS 2` and `### Strength vs density` flows directly now).
- [ ] Confirm zone-template Wilcoxon panels render with adjusted p-values when `n_treats > 1 && n_reps == n_common_reps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)